### PR TITLE
add support for promises in IE11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pura",
-  "version": "4.0.3",
+  "version": "4.1.0",
   "scripts": {
     "test": "./tasks/subtasks/lint.sh",
     "deploy": "./tasks/deploy.sh",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "xo": "^0.18.2"
   },
   "dependencies": {
+    "es6-promise": "^4.1.1",
     "normalize.css": "^7.0.0",
     "picturefill": "^3.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
     "xo": "^0.18.2"
   },
   "dependencies": {
-    "es6-promise": "^4.1.1",
     "normalize.css": "^7.0.0",
-    "picturefill": "^3.0.2"
+    "picturefill": "^3.0.2",
+    "promise-polyfill": "^6.1.0"
   },
   "browserslist": [
     "last 2 versions"

--- a/src/assets/scripts/app.js
+++ b/src/assets/scripts/app.js
@@ -1,3 +1,5 @@
+require('es6-promise').polyfill();
+
 if (document.querySelectorAll('[data-my-module]').length) {
   System.import('./MyModule').then(module => new module.default());
 }

--- a/src/assets/scripts/app.js
+++ b/src/assets/scripts/app.js
@@ -1,6 +1,5 @@
 import Promise from 'promise-polyfill';
 
-// Add promise-polyfill to window
 if (!window.Promise) {
   window.Promise = Promise;
 }

--- a/src/assets/scripts/app.js
+++ b/src/assets/scripts/app.js
@@ -1,4 +1,9 @@
-require('es6-promise').polyfill();
+import Promise from 'promise-polyfill';
+
+// Add promise-polyfill to window
+if (!window.Promise) {
+  window.Promise = Promise;
+}
 
 if (document.querySelectorAll('[data-my-module]').length) {
   System.import('./MyModule').then(module => new module.default());

--- a/yarn.lock
+++ b/yarn.lock
@@ -2011,10 +2011,6 @@ es6-map@^0.1.3:
     es6-symbol "~3.1.1"
     event-emitter "~0.3.5"
 
-es6-promise@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.1.1.tgz#8811e90915d9a0dba36274f0b242dbda78f9c92a"
-
 es6-set@~0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/es6-set/-/es6-set-0.1.5.tgz#d2b3ec5d4d800ced818db538d28974db0a73ccb1"
@@ -4649,6 +4645,10 @@ promise-each@^2.2.0:
   resolved "https://registry.yarnpkg.com/promise-each/-/promise-each-2.2.0.tgz#3353174eff2694481037e04e01f77aa0fb6d1b60"
   dependencies:
     any-promise "^0.1.0"
+
+promise-polyfill@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-6.1.0.tgz#dfa96943ea9c121fca4de9b5868cb39d3472e057"
 
 promise.pipe@^3.0.0:
   version "3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2011,6 +2011,10 @@ es6-map@^0.1.3:
     es6-symbol "~3.1.1"
     event-emitter "~0.3.5"
 
+es6-promise@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.1.1.tgz#8811e90915d9a0dba36274f0b242dbda78f9c92a"
+
 es6-set@~0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/es6-set/-/es6-set-0.1.5.tgz#d2b3ec5d4d800ced818db538d28974db0a73ccb1"
@@ -4692,13 +4696,13 @@ qs@6.2.1:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.2.1.tgz#ce03c5ff0935bc1d9d69a9f14cbd18e568d67625"
 
-"qs@>= 0.4.0", qs@~6.4.0:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
-
-qs@~6.3.0:
+"qs@>= 0.4.0", qs@~6.3.0:
   version "6.3.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.3.2.tgz#e75bd5f6e268122a2a0e0bda630b2550c166502c"
+
+qs@~6.4.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
 
 querystring-es3@^0.2.0:
   version "0.2.1"


### PR DESCRIPTION
Until we stop supporting IE for all of eternity, is it ok to add support for it out of the box? 