### PR TITLE
5.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pura",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "scripts": {
     "test": "jest",
     "precommit": "lint-staged",

--- a/package.json
+++ b/package.json
@@ -229,10 +229,7 @@
         }
       ],
       "number-leading-zero": "always",
-      "function-parentheses-space-inside": "never",
-      "function-comma-space-after": "always",
       "at-rule-name-space-after": "always",
-      "declaration-colon-newline-after": "always-multi-line",
       "declaration-property-unit-blacklist": {
         "font-size": [
           "px"

--- a/tasks/subtasks/revAssets.js
+++ b/tasks/subtasks/revAssets.js
@@ -5,10 +5,14 @@ const globby = require("globby");
 const assets = ["src/_compiled/*.css", "src/_compiled/*.js"];
 
 (async () => {
-  const paths = await globby(assets);
+  try {
+    const paths = await globby(assets);
 
-  new Version({
-    assets: paths,
-    grepFiles: [`./src${settings.templatePath}`]
-  }).run();
+    new Version({
+      assets: paths,
+      grepFiles: [`./src${settings.templatePath}`]
+    }).run();
+  } catch (err) {
+    console.error(err);
+  }
 })();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,6 +18,7 @@ module.exports = {
     rules: [
       {
         test: /\.jsx?$/,
+        exclude: /node_modules/,
         use: [
           {
             loader: "babel-loader"


### PR DESCRIPTION
- [x] Wrap `revAssets.js` task in a `try...catch` block
- [x] Exclude `node_modules/` from the Webpack babel-loader tool
- [x] Remove Prettier-influenced Stylelint rules